### PR TITLE
Update shortcut discovery method

### DIFF
--- a/Chrome.ahk
+++ b/Chrome.ahk
@@ -67,7 +67,10 @@
 		
 		; Verify ChromePath
 		if (ChromePath == "")
-			FileGetShortcut, %A_StartMenuCommon%\Programs\Google Chrome.lnk, ChromePath
+			; By using winmgmts to get the path of a shortcut file we fix an edge case where the path is retreived incorrectly
+			; if using the ahk executable with a different architecture than the OS (using 32bit AHK on a 64bit OS for example)
+			 ChromePath := ComObjGet("winmgmts:").ExecQuery("Select * from Win32_ShortcutFile where Name=""" StrReplace(A_StartMenuCommon "\Programs\Google Chrome.lnk", "\", "\\") """").ItemIndex(0).Target
+			; FileGetShortcut, %A_StartMenuCommon%\Programs\Google Chrome.lnk, ChromePath
 		if (ChromePath == "")
 			RegRead, ChromePath, HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe
 		if !FileExist(ChromePath)


### PR DESCRIPTION
FileGetShortcut gets the path from a lnk file in an unreliable way and in some edge cases you get the wrong path.
Using winmgmts the process is more robust and makes sure to get the correct path even if theres an Executable vs OS mismatch (running 32bit files on 64bit OS)