### PR TITLE
fix callback routine thread lock issue

### DIFF
--- a/Chrome.ahk
+++ b/Chrome.ahk
@@ -313,9 +313,14 @@
 				data := Chrome.Jxon_Load(Event.data)
 				
 				; Run the callback routine
+				fnCallback := this.fnCallback.Bind(this, data)
+				SetTimer, %fnCallback%, -0
+				
+				/*
 				fnCallback := this.fnCallback
 				if (newData := %fnCallback%(data))
 					data := newData
+				*/
 				
 				if this.responses.HasKey(data.ID)
 					this.responses[data.ID] := data


### PR DESCRIPTION
When making calls for devtools domains from an event callback function chrome.ahk enters an infinite loop because of a thread lock issue