### PR TITLE
3 improvements.

### DIFF
--- a/Chrome.ahk
+++ b/Chrome.ahk
@@ -62,7 +62,11 @@
 	{
 		; Verify ProfilePath
 		if (ProfilePath != "" && !InStr(FileExist(ProfilePath), "D"))
-			throw Exception("The given ProfilePath does not exist")
+		{
+			FileCreateDir, %ProfilePath%
+			if (ErrorLevel = 1)
+				throw Exception("Failed to create the profile directory")
+		}
 		this.ProfilePath := ProfilePath
 		
 		; Verify ChromePath

--- a/Chrome.ahk
+++ b/Chrome.ahk
@@ -117,9 +117,23 @@
 	*/
 	GetPageList()
 	{
+		ComObjError(0)
 		http := ComObjCreate("WinHttp.WinHttpRequest.5.1")
-		http.open("GET", "http://127.0.0.1:" this.DebugPort "/json")
-		http.send()
+		; It is easy to fail here because "new chrome ()" takes a long time to execute.
+		; Therefore, it will be tried again and again within 10 seconds until it succeeds or times out.
+		StartTime := A_TickCount
+		while (A_TickCount-StartTime < 10*1000)
+		{
+			http.SetTimeouts(30000, 30000, 30000, 30000)
+			http.Open("GET", "http://127.0.0.1:" this.DebugPort "/json", true)
+			http.Send()
+			http.WaitForResponse(-1)
+			if (http.Status = 200)
+				break
+			else
+				Sleep, 1000
+		}
+		ComObjError(1)
 		return this.Jxon_Load(http.responseText)
 	}
 	

--- a/Chrome.ahk
+++ b/Chrome.ahk
@@ -66,10 +66,12 @@
 		this.ProfilePath := ProfilePath
 		
 		; Verify ChromePath
+		ComObjError(0)
 		if (ChromePath == "")
 			; By using winmgmts to get the path of a shortcut file we fix an edge case where the path is retreived incorrectly
 			; if using the ahk executable with a different architecture than the OS (using 32bit AHK on a 64bit OS for example)
 			 ChromePath := ComObjGet("winmgmts:").ExecQuery("Select * from Win32_ShortcutFile where Name=""" StrReplace(A_StartMenuCommon "\Programs\Google Chrome.lnk", "\", "\\") """").ItemIndex(0).Target
+		ComObjError(1)
 			; FileGetShortcut, %A_StartMenuCommon%\Programs\Google Chrome.lnk, ChromePath
 		if (ChromePath == "")
 			RegRead, ChromePath, HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe

--- a/Examples/EventCallbacks.ahk
+++ b/Examples/EventCallbacks.ahk
@@ -11,7 +11,6 @@ TestPages := 3
 ; https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
 DataURL =
 ( Comments
-data:Text/html, ; This line makes it a URL
 <!DOCTYPE html>
 <html>
 	<head>
@@ -51,7 +50,12 @@ JS =
 ; Define an array of pages to open
 DataURLs := []
 Loop, %TestPages%
-	DataURLs.Push(Format(DataURL, A_Index))
+{
+	File := Format("{}\{}.html", A_Temp, A_Index)
+	FileDelete, % File
+	FileAppend, % Format(DataURL, A_Index), % File
+	DataURLs.Push(File)
+}
 
 ; Open Chrome with those pages
 FileCreateDir, ChromeProfile
@@ -67,7 +71,7 @@ Loop, %TestPages%
 	BoundCallback := Func("Callback").Bind(A_Index)
 	
 	; Get an instance of the page, passing in the callback function
-	if !(PageInst := ChromeInst.GetPageByTitle(A_Index, "contains",, BoundCallback))
+	if !(PageInst := ChromeInst.GetPageByTitle(A_Index, "contains",,, BoundCallback))
 	{
 		MsgBox, Could not retrieve page %A_Index%!
 		ChromeInst.Kill()


### PR DESCRIPTION
47e1b50
If chrome.lnk is not found, we can still get a clear error info (Chrome could not be found) here instead of a com error info.

7d3e25b
It is easy to fail here because "new chrome ()" takes a long time to execute.
Therefore, it will be tried again and again within 10 seconds until it succeeds or times out.

262f0db
When the profilepath given by the user does not exist, try to create it.
In this way, chrome can be simply run with a brand-new identity.
Therefore, the user can specify an existing identity to run, or simply create a new identity for automation and keep it there all the time.